### PR TITLE
Fix #22: ajout d'une bannière de redirection quand la variable VITE_REDIRECT_DOMAIN est définie

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -16,6 +16,7 @@ const migrate = reactive({
   redirectDomain: import.meta.env.VITE_REDIRECT_DOMAIN,
   currentDomain: window.location.hostname || 'administrans.fr',
   migrateUrl: null,
+  show: true,
 })
 
 function migrateData () {
@@ -117,7 +118,7 @@ watch(
   <main>
     <div
       class="width--narrow message--primary my-2 px-2 py-2 hide-for-print"
-      v-if="migrate.migrateUrl"
+      v-if="migrate.migrateUrl && migrate.show"
     >
       <p>
         <strong>
@@ -126,6 +127,7 @@ watch(
       </p>
       <p>Vos données ne seront pas perdues. Cliquez sur le lien ci-dessous pour être redirigé·e immédiatement.</p>
       <a :href="migrate.migrateUrl" class="button">Migrer vers {{ migrate.redirectDomain }}</a>
+      <a href="#" class="mx-2" @click.prevent="migrate.show = false">Me le rappeler plus tard</a>
     </div>
     <RouterView />
   </main>

--- a/src/store.js
+++ b/src/store.js
@@ -11,18 +11,22 @@ const storage = {
   }
 }
 
+export function getDefaultState () {
+  return {
+    formData: {},
+    steps: {},
+    CecMethod: 'prénomPuisSexe',
+    situation: 'françaisRésidantEnFrance',
+  }
+}
+
 export const useGlobalStore = defineStore('global', {
   persist: {
     key: 'store.global',
     paths: ['formData', 'steps', 'CecMethod', 'situation'],
     storage: storage,
   },
-  state: () => ({
-    formData: {},
-    steps: {},
-    CecMethod: 'prénomPuisSexe',
-    situation: 'françaisRésidantEnFrance',
-  }),
+  state: () => (getDefaultState()),
   actions: {
     persistFormData(data) {
       this.formData = {
@@ -41,7 +45,7 @@ export const useGlobalStore = defineStore('global', {
     },
 
     deleteData() {
-      this.formData = {}
+      Object.assign(this, getDefaultState())
     }
   }
 })

--- a/src/store.js
+++ b/src/store.js
@@ -44,6 +44,14 @@ export const useGlobalStore = defineStore('global', {
       this.situation = value
     },
 
+    importData(data) {
+      let defaultState = getDefaultState()
+      this.formData = data.formData || defaultState.formData
+      this.steps = data.steps || defaultState.steps
+      this.CecMethod = data.CecMethod || defaultState.CecMethod
+      this.situation = data.situation || defaultState.situation
+    },
+
     deleteData() {
       Object.assign(this, getDefaultState())
     }


### PR DESCRIPTION
**Ne pas merger pour l'instant.**

Pour tester localement : 

1. `VITE_REDIRECT_DOMAIN=localhost yarn dev --host=127.0.0.1`
2. Une bannière est proposée pour rediriger vers le nouveau domaine
3. Faire des choses qui stockent des données comme docher des cases sur la page /cec
4. Cliquer sur le bouton
5. Vérifier qu'on est bien redirigé de 127.0.0.1 vers localhost et que les donées des formulaires / checklists sont identiques sur localhost et 127.0.0.1
6. La bannière ne doit plus être affichée

Tests en local apprécié pour vérifier que tout fonctionne 

![image](https://github.com/agateblue/administrans/assets/1970915/cdd2c8ff-568a-41da-acdf-99e0a9e4e9e6)

