### PR TITLE
fix: exemples de documents avec accord du genre dynamique

### DIFF
--- a/src/components/DynamicForm.vue
+++ b/src/components/DynamicForm.vue
@@ -1,10 +1,11 @@
 <script setup>
 import { reactive } from 'vue'
 import { renderMarkdown } from '@/utils'
+import { renderWithGender, genderSwitch } from '@/lib/utils/gender'
 
-const emit = defineEmits( ['update:modelValue', 'submit'] )
+const emit = defineEmits(['update:modelValue', 'submit'])
 
-const props = defineProps( {
+const props = defineProps({
   structure: {
     type: Array,
     required: true
@@ -17,37 +18,58 @@ const props = defineProps( {
     type: Boolean,
     default: false
   }
-} )
+})
 
 const fieldsById = {}
-props.structure.forEach( ( e ) => {
-  if ( e.isInput ) {
+props.structure.forEach((e) => {
+  if (e.isInput) {
     fieldsById[e.id] = e
   }
-} )
-const localData = reactive( { ...props.modelValue } )
-function handleUpdate ( field, value ) {
-  if ( field.injectInto ) {
-    // we implement extremely basic templating here
-    // so we can inject values from other fields
-    // in the value before injection in another field
-    let injectData = { ...localData }
-    injectData.sexe = injectData.genre === 'masculin' ? 'homme' : 'femme'
-    value = value.replace( '{{ sexe }}', injectData.sexe )
-    props.structure.forEach( ( f ) => {
-      if ( f.isInput ) {
-        const search = `{{ ${f.id} }}`
-        value = value.replace( search, injectData[f.id] )
-      }
-    } )
-    localData[field.injectInto] = value.trim()
+})
+const localData = reactive({ ...props.modelValue })
+
+function applyInjectTemplate(field, rawValue) {
+  const injectData = { ...localData, [field.id]: rawValue }
+  const gender = injectData.genre
+  injectData.sexe = gender === 'masculin' ? 'homme' : 'femme'
+  injectData.satisfait = renderWithGender('satisfait', gender)
+  injectData.equilibre = genderSwitch('équilibré', 'équilibrée', gender)
+
+  let value = rawValue
+  value = value.replace('{{ sexe }}', injectData.sexe)
+  value = value.replace('{{ satisfait }}', injectData.satisfait)
+  value = value.replace('{{ equilibre }}', injectData.equilibre)
+  props.structure.forEach((f) => {
+    if (f.isInput) {
+      value = value.replace(`{{ ${f.id} }}`, injectData[f.id] ?? '')
+    }
+  })
+
+  localData[field.id] = rawValue
+  localData[field.injectInto] = value.trim()
+}
+
+function reInjectExamples() {
+  props.structure.forEach((f) => {
+    if (f.injectInto && localData[f.id]) {
+      applyInjectTemplate(f, localData[f.id])
+    }
+  })
+}
+
+function handleUpdate(field, value) {
+  if (field.injectInto) {
+    applyInjectTemplate(field, value)
   } else {
     localData[field.id] = value
+    if (field.id === 'genre') {
+      reInjectExamples()
+    }
   }
   if (field.action) {
     field.action(localData)
   }
-  emit( 'update:modelValue', localData )
+  emit('update:modelValue', localData)
 }
 </script>
 
@@ -57,29 +79,58 @@ function handleUpdate ( field, value ) {
       <template v-for="element in props.structure" :key="JSON.stringify(element)">
         <template v-if="element.showCondition(localData)">
           <h2 v-if="element.isCategory" class="category">{{ element.name }}</h2>
-          <div v-if="element.isInput" :class="['field', `field--${element.type}`, element.class || '']">
+          <div
+            v-if="element.isInput"
+            :class="['field', `field--${element.type}`, element.class || '']"
+          >
             <label v-if="element.type != 'checkbox'" :for="`field-${element.id}`">{{
               element.name
             }}</label>
-            <textarea v-if="element.type === 'textarea'" :value="localData[element.id]" :id="`field-${element.id}`"
-              v-bind="element.attributes || { rows: 3 }" @input="handleUpdate(element, $event.target.value)"
-              :disabled="disabled" :placeholder="element.placeholder">
+            <textarea
+              v-if="element.type === 'textarea'"
+              :value="localData[element.id]"
+              :id="`field-${element.id}`"
+              v-bind="element.attributes || { rows: 3 }"
+              @input="handleUpdate(element, $event.target.value)"
+              :disabled="disabled"
+              :placeholder="element.placeholder"
+            >
             </textarea>
-            <select v-else-if="element.type === 'select'" :value="localData[element.id]" :id="`field-${element.id}`"
-              @input="handleUpdate(element, $event.target.value)" :disabled="disabled">
+            <select
+              v-else-if="element.type === 'select'"
+              :value="localData[element.id]"
+              :id="`field-${element.id}`"
+              @change="handleUpdate(element, $event.target.value)"
+              :disabled="disabled"
+            >
               <option v-for="(v, i) in element.choices" :key="i" :value="v.value">
                 {{ v.label }}
               </option>
             </select>
             <div v-else-if="element.type === 'checkbox'" class="checkbox">
-              <input type="checkbox" :checked="localData[element.id]" :id="`field-${element.id}`"
-                @change="handleUpdate(element, $event.target.checked)" :disabled="disabled" />
+              <input
+                type="checkbox"
+                :checked="localData[element.id]"
+                :id="`field-${element.id}`"
+                @change="handleUpdate(element, $event.target.checked)"
+                :disabled="disabled"
+              />
               <label :for="`field-${element.id}`">{{ element.name }}</label>
             </div>
-            <input v-else :type="element.type || 'text'" :value="localData[element.id]" :id="`field-${element.id}`"
-              @input="handleUpdate(element, $event.target.value)" :disabled="disabled"
-              :placeholder="element.placeholder" />
-            <div v-if="element.help" class="text--small text--italic" v-html="renderMarkdown(element.help)"></div>
+            <input
+              v-else
+              :type="element.type || 'text'"
+              :value="localData[element.id]"
+              :id="`field-${element.id}`"
+              @input="handleUpdate(element, $event.target.value)"
+              :disabled="disabled"
+              :placeholder="element.placeholder"
+            />
+            <div
+              v-if="element.help"
+              class="text--small text--italic"
+              v-html="renderMarkdown(element.help)"
+            ></div>
           </div>
         </template>
       </template>

--- a/src/documents-templates/AttestationTemoignage.vue
+++ b/src/documents-templates/AttestationTemoignage.vue
@@ -1,21 +1,20 @@
 <script setup>
 import useDocumentTemplate from '@/templates'
 
-const p = defineProps( { data: { type: Object }, structure: { type: Array } } )
-const {
-  renderValue,
-  renderWithGender,
-  renderDate,
-  renderFullDescription
-} = useDocumentTemplate( p )
+const p = defineProps({ data: { type: Object }, structure: { type: Array } })
+const { renderValue, renderDate, renderFullDescription, renderWithGender } = useDocumentTemplate(p)
 </script>
 
 <template>
   <div class="grid--row">
     <div class="grid--column">
       <div class="adress--sender" v-if="renderValue('adresseTiers')">
-        {{ renderValue('prénomTiers') }} {{ renderValue('nomTiers') }}<br />{{ renderValue('adresseTiers') }}
-        <template v-if="data['téléphoneTiers']"><br />Téléphone : {{ renderValue('téléphoneTiers') }}</template>
+        {{ renderValue('prénomTiers') }} {{ renderValue('nomTiers') }}<br />{{
+          renderValue('adresseTiers')
+        }}
+        <template v-if="data['téléphoneTiers']"
+          ><br />Téléphone : {{ renderValue('téléphoneTiers') }}</template
+        >
         <template v-if="data['emailTiers']"><br />Email : {{ renderValue('emailTiers') }}</template>
       </div>
     </div>
@@ -35,20 +34,19 @@ const {
   </p>
   <p>Madame, Monsieur,</p>
   <p>
-    Je sous-{{ renderWithGender('signé', 'genreTiers') }}
-    {{ renderValue('prénomTiers') }} {{ renderValue('nomTiers') }},
-    {{ renderWithGender('né', 'genreTiers') }} le {{ renderDate('dateNaissanceTiers') }}
-    à {{ renderValue('lieuNaissanceTiers') }},
-    demeurant au {{ renderValue('adresseTiers') }}
+    Je sous-{{ renderWithGender('signé', 'genreTiers') }} {{ renderValue('prénomTiers') }}
+    {{ renderValue('nomTiers') }}, {{ renderWithGender('né', 'genreTiers') }} le
+    {{ renderDate('dateNaissanceTiers') }} à {{ renderValue('lieuNaissanceTiers') }}, demeurant au
+    {{ renderValue('adresseTiers') }}
     déclare sur l'honneur
     <template v-if="data.typeAttestation === 'prénom'">
       <template v-if="data.deadname && data.deadname.trim()">
-        n'appeler {{ renderFullDescription() }} que par son véritable prénom {{ renderValue('prénom') }} {{
-          renderValue('nom') }}.
+        n'appeler {{ renderFullDescription() }} que par son véritable prénom
+        {{ renderValue('prénom') }} {{ renderValue('nom') }}.
       </template>
       <template v-else>
-        ignorer le prénom d'état civil de {{ renderFullDescription() }} et ne l'appeler que {{ renderValue('prénom') }} {{
-          renderValue('nom') }}.
+        ignorer le prénom d'état civil de {{ renderFullDescription() }} et ne l'appeler que
+        {{ renderValue('prénom') }} {{ renderValue('nom') }}.
       </template>
     </template>
     <template v-else-if="data.typeAttestation === 'genre'">
@@ -57,20 +55,19 @@ const {
     <template v-else>
       genrer {{ renderFullDescription() }} exclusivement au {{ renderValue('genre') }}.
       <template v-if="data.deadname && data.deadname.trim()">
-        Je ne l'appelle que par son véritable prénom {{ renderValue('prénom') }} {{ renderValue('nom') }}.
+        Je ne l'appelle que par son véritable prénom {{ renderValue('prénom') }}
+        {{ renderValue('nom') }}.
       </template>
       <template v-else>
-        J'ignore son prénom d'état civil et ne l'appelle que {{ renderValue('prénom') }} {{ renderValue('nom') }}.
+        J'ignore son prénom d'état civil et ne l'appelle que {{ renderValue('prénom') }}
+        {{ renderValue('nom') }}.
       </template>
-
     </template>
   </p>
   <p v-if="data.contenuAttestation && data.contenuAttestation.trim()">
     {{ data.contenuAttestation }}
   </p>
-  <p>
-    Fait pour faire valoir ce que de droit,
-  </p>
+  <p>Fait pour faire valoir ce que de droit,</p>
   <p class="signature">{{ renderValue('prénomTiers') }} {{ renderValue('nomTiers') }}</p>
   <p>Pièces jointes :</p>
   <ul class="attachments">

--- a/src/documents-templates/DemandeMaj.vue
+++ b/src/documents-templates/DemandeMaj.vue
@@ -10,7 +10,9 @@ const { renderValue, genderSwitch, renderWithGender } = useDocumentTemplate(p)
     <div class="grid--column">
       <div class="adress--sender" v-if="renderValue('adresse')">
         {{ renderValue('prénom') }} {{ renderValue('nom') }}<br />{{ renderValue('adresse') }}
-        <template v-if="data['téléphone']"><br />Téléphone : {{ renderValue('téléphone') }}</template>
+        <template v-if="data['téléphone']"
+          ><br />Téléphone : {{ renderValue('téléphone') }}</template
+        >
         <template v-if="data['email']"><br />Email : {{ renderValue('email') }}</template>
       </div>
     </div>
@@ -24,12 +26,8 @@ const { renderValue, genderSwitch, renderWithGender } = useDocumentTemplate(p)
   </div>
   <p class="subject">
     Objet : Demande de changement
-    <template v-if="data['changementDemandé'] === 'prénom'">
-      de prénom
-    </template>
-    <template v-if="data['changementDemandé'] === 'civilité'">
-      de civilité
-    </template>
+    <template v-if="data['changementDemandé'] === 'prénom'"> de prénom </template>
+    <template v-if="data['changementDemandé'] === 'civilité'"> de civilité </template>
     <template v-if="data['changementDemandé'] === 'prénomEtCivilité'">
       de prénom et de civilité
     </template>
@@ -37,14 +35,11 @@ const { renderValue, genderSwitch, renderWithGender } = useDocumentTemplate(p)
   </p>
   <p>Madame, Monsieur,</p>
   <p>
-    Je suis {{ renderValue('prénom') }} {{ renderValue('nom').toUpperCase() }} et je souhaite effectuer les démarches de changement 
+    Je suis {{ renderValue('prénom') }} {{ renderValue('nom').toUpperCase() }} et je souhaite
+    effectuer les démarches de changement
 
-    <template v-if="data['changementDemandé'] === 'prénom'">
-      de prénom
-    </template>
-    <template v-if="data['changementDemandé'] === 'civilité'">
-      de civilité
-    </template>
+    <template v-if="data['changementDemandé'] === 'prénom'"> de prénom </template>
+    <template v-if="data['changementDemandé'] === 'civilité'"> de civilité </template>
     <template v-if="data['changementDemandé'] === 'prénomEtCivilité'">
       de prénom et de civilité
     </template>
@@ -63,66 +58,64 @@ const { renderValue, genderSwitch, renderWithGender } = useDocumentTemplate(p)
     Vous trouverez en pièce jointe la décision de changement de prénom délivrée par l'état civil.
   </p>
   <p v-if="data.ajouterCSEC && data['changementDemandé'] != 'prénom'">
-    J'ai déjà obtenu un changement de mention de sexe à l'état-civil. Vous trouverez en pièce jointe une copie de la décision du tribunal.
+    J'ai déjà obtenu un changement de mention de sexe à l'état-civil. Vous trouverez en pièce jointe
+    une copie de la décision du tribunal.
   </p>
   <template v-if="data['changementDemandé'] != 'prénom'">
     <p>
-
-      Je vous demande <template v-if="data['changementDemandé'] === 'prénomEtCivilité'">par ailleurs</template> de bien vouloir changer ma civilité de « {{ genderSwitch('Madame', 'Monsieur', 'civilité') }} » à
-      « {{ genderSwitch('Monsieur', 'Madame', 'civilité') }} » dans vos registres, et ce préalablement à toute décision de changement de mention de sexe à l’État-Civil, puisque je suis une personne transgenre.
+      Je vous demande
+      <template v-if="data['changementDemandé'] === 'prénomEtCivilité'">par ailleurs</template> de
+      bien vouloir changer ma civilité de « {{ genderSwitch('Madame', 'Monsieur', 'civilité') }} » à
+      « {{ genderSwitch('Monsieur', 'Madame', 'civilité') }} » dans vos registres, et ce
+      préalablement à toute décision de changement de mention de sexe à l’État-Civil, puisque je
+      suis une personne transgenre.
     </p>
     <p>
-      En effet, comme l’a rappelé de nombreuses fois le Défenseur des Droits dans
-      des rapports, synthèses, recommandations et décisions, la civilité est une affaire
-      d’usage et n’est aucunement liée à la mention de sexe à l’État-Civil. Je vous
-      engage à vous renseigner sur le site du Défenseur des Droits si le
-      moindre doute persiste.
+      En effet, comme l’a rappelé de nombreuses fois le Défenseur des Droits dans des rapports,
+      synthèses, recommandations et décisions, la civilité est une affaire d’usage et n’est
+      aucunement liée à la mention de sexe à l’État-Civil. Je vous engage à vous renseigner sur le
+      site du Défenseur des Droits si le moindre doute persiste.
     </p>
     <p>
-      De surcroit, il a noté qu’une persistance d’une civilité erronée, c’est-à-dire non
-      conforme à l’identité de genre réelle d’une personne transgenre, relevait du harcèlement
-      discriminatoire basé sur l’identité de genre.
+      De surcroit, il a noté qu’une persistance d’une civilité erronée, c’est-à-dire non conforme à
+      l’identité de genre réelle d’une personne transgenre, relevait du harcèlement discriminatoire
+      basé sur l’identité de genre.
     </p>
   </template>
   <p>
-    Par conséquent, je vous demande de mettre à jour, dans les plus brefs
-    délais, 
-    <template v-if="data['changementDemandé'] === 'prénom'">
-      mon prénom
-    </template>
-    <template v-if="data['changementDemandé'] === 'civilité'">
-      ma civilité
-    </template>
+    Par conséquent, je vous demande de mettre à jour, dans les plus brefs délais,
+    <template v-if="data['changementDemandé'] === 'prénom'"> mon prénom </template>
+    <template v-if="data['changementDemandé'] === 'civilité'"> ma civilité </template>
     <template v-if="data['changementDemandé'] === 'prénomEtCivilité'">
       mon prénom et ma civilité
     </template>
-    dans vos registres, et de me tenir {{ renderWithGender('informé', 'civilité') }} 
+    dans vos registres, et de me tenir {{ renderWithGender('informé', 'civilité') }}
     de la bonne prise en compte de ces informations.
   </p>
   <p v-if="data.mentionDDDEtCnil">
-    Faute d’une rapide modification de ces informations et d’un prompt retour de
-    votre part, je me verrais {{ renderWithGender('contraint', 'civilité') }} de saisir le Défenseur des Droits et la CNIL.
+    Faute d’une rapide modification de ces informations et d’un prompt retour de votre part, je me
+    verrais {{ renderWithGender('contraint', 'civilité') }} de saisir le Défenseur des Droits et la
+    CNIL.
   </p>
   <p>
     Je vous remercie de l'aide que vous m'apporterez dans ma démarche et vous prie de bien vouloir
     croire, Madame, Monsieur, en l'assurance de ma considération,
   </p>
   <p class="signature">{{ renderValue('prénom') }} {{ renderValue('nom') }}</p>
-  <hr class="hidden">
-  <hr class="hidden">
-  <hr class="hidden">
-  <hr class="hidden">
-  <hr class="hidden">
+  <hr class="hidden" />
+  <hr class="hidden" />
+  <hr class="hidden" />
+  <hr class="hidden" />
+  <hr class="hidden" />
   <p>Pièces jointes :</p>
   <ul class="attachments">
-    <li>
-      Copie de la pièce d'identité de {{ renderValue('prénom') }} {{ renderValue('nom') }}
-    </li>
+    <li>Copie de la pièce d'identité de {{ renderValue('prénom') }} {{ renderValue('nom') }}</li>
     <li v-if="data['changementDemandé'] != 'civilité'">
       Décision de changement de prénom de {{ renderValue('prénom') }} {{ renderValue('nom') }}
     </li>
     <li v-if="data.ajouterCSEC && data['changementDemandé'] != 'prénom'">
-      Décision du tribunal du changement de sexe à l'état civil de {{ renderValue('prénom') }} {{ renderValue('nom') }}
+      Décision du tribunal du changement de sexe à l'état civil de {{ renderValue('prénom') }}
+      {{ renderValue('nom') }}
     </li>
   </ul>
 </template>

--- a/src/documents-templates/RequeteCecTribunal.vue
+++ b/src/documents-templates/RequeteCecTribunal.vue
@@ -2,62 +2,63 @@
 import useDocumentTemplate from '@/templates'
 import { renderMarkdown } from '@/utils'
 
-const p = defineProps( { data: { type: Object }, structure: { type: Array } } )
-const { renderValue, genderSwitch, renderWithGender, renderDate } = useDocumentTemplate( p )
-
+const p = defineProps({ data: { type: Object }, structure: { type: Array } })
+const { renderValue, renderDate, genderSwitch, renderWithGender } = useDocumentTemplate(p)
 </script>
 
 <template>
   <div class="requete">
     <p class="text--right">
       À Mesdames et Messieurs les Président et Juges
-      <br> de la Chambre du Conseil du
+      <br />
+      de la Chambre du Conseil du
       {{ renderValue('tribunal') }}
     </p>
     <p class="text--right">{{ renderValue('adresseTribunal') }}</p>
-    <h1 v-if="data.typeChangement === 'genre'">Requête en changement de la mention du sexe à l'état civil</h1>
+    <h1 v-if="data.typeChangement === 'genre'">
+      Requête en changement de la mention du sexe à l'état civil
+    </h1>
     <h1 v-else>Requête en changement de la mention du sexe et des prénoms à l'état civil</h1>
     <p>
-      Devant la Chambre du Conseil <br>
-      (article 1055-8 du Code de procédure civile)<br>
-      (article 1055-7 CpC : « Le ministère d’avocat n’est pas obligatoire »)<br>
+      Devant la Chambre du Conseil <br />
+      (article 1055-8 du Code de procédure civile)<br />
+      (article 1055-7 CpC : « Le ministère d’avocat n’est pas obligatoire »)<br />
     </p>
-    <hr>
+    <hr />
     <p>
-      <strong>
-        À la demande de :
-      </strong>
-      <br>
+      <strong> À la demande de : </strong>
+      <br />
       {{ genderSwitch('Madame', 'Monsieur', 'genre') }}
       {{ renderValue('nom').toUpperCase() }} {{ renderValue('prénomsActuels') }}
       {{ renderWithGender('dit') }}
       {{ genderSwitch('Monsieur', 'Madame', 'genre') }}
-      {{ renderValue('nom').toUpperCase() }} {{ renderValue('nouveauxPrénoms', data.prénomsActuels) }}
-      <br>
-      {{ renderWithGender('Né') }} le {{ renderDate('dateNaissance') }} à {{ renderValue('lieuNaissance') }},
-      de nationalité {{ renderValue('nationalité') }}
-      <br>
+      {{ renderValue('nom').toUpperCase() }}
+      {{ renderValue('nouveauxPrénoms', data.prénomsActuels) }}
+      <br />
+      {{ renderWithGender('Né') }} le {{ renderDate('dateNaissance') }} à
+      {{ renderValue('lieuNaissance') }}, de nationalité
+      {{ renderValue('nationalité') }}
+      <br />
       {{ renderValue('situationProfessionnelle') }}
-      <br>
+      <br />
       {{ renderValue('situationFamiliale') }}
-      <br>
+      <br />
       Résidant au {{ renderValue('adresse') }}
-      <br>
+      <br />
       {{ renderValue('téléphone') }}, {{ renderValue('email') }}
-      <br>
+      <br />
       Sans avocat, présentant sa requête en personne.
     </p>
     <p>
-      <strong>
-        En présence de :
-      </strong>
-      <br>
-      Madame la Procureure ou Monsieur le Procureur de la République
-      Près le Tribunal Judiciaire de {{ renderValue('villeTribunal') }}.
+      <strong> En présence de : </strong>
+      <br />
+      Madame la Procureure ou Monsieur le Procureur de la République Près le Tribunal Judiciaire de
+      {{ renderValue('villeTribunal') }}.
     </p>
     <p>
       <strong>
-        Moi même {{ genderSwitch('le requérant', 'la requérante') }}, a l'honneur d'exposer ce qui suit :
+        Moi même {{ genderSwitch('le requérant', 'la requérante') }}, a l'honneur d'exposer ce qui
+        suit :
       </strong>
     </p>
     <h2>Les faits</h2>
@@ -68,255 +69,311 @@ const { renderValue, genderSwitch, renderWithGender, renderDate } = useDocumentT
       à l'état civil
     </h2>
     <p>
-      L’article 8 de la Convention Européenne des Droits de l’Homme reconnaît à la personne déclarée de sexe {{
-        genderSwitch('féminin', 'masculin') }} à l’officier d’état civil le droit de rectification de son état civil, dès
-      lors que, après traitement hormonal et intervention chirurgicale, cette personne ne présente pas les
-      caractéristiques de son sexe d’origine et a pris l’apparence physique qui la rapproche de l’autre sexe.
+      L’article 8 de la Convention Européenne des Droits de l’Homme reconnaît à la personne déclarée
+      de sexe
+      {{ genderSwitch('féminin', 'masculin') }} à l’officier d’état civil le droit de rectification
+      de son état civil, dès lors que, après traitement hormonal et intervention chirurgicale, cette
+      personne ne présente pas les caractéristiques de son sexe d’origine et a pris l’apparence
+      physique qui la rapproche de l’autre sexe.
     </p>
     <p>
-      La jurisprudence de principe de la Cour de Cassation admet également la recevabilité et le bien-fondé de cette
-      action lorsqu’à la suite d’un traitement médico-chirurgical suivi dans un but thérapeutique, une personne présentant
-      le syndrome du transsexualisme ne possède plus tous les caractères de son sexe d’origine et a pris l’apparence
-      physique la rapprochant de l’autre sexe, auquel correspond son comportement social : Le principe du respect de la
-      vie privé justifie alors que son état civil indique désormais le sexe dont elle a pris l’apparence.
+      La jurisprudence de principe de la Cour de Cassation admet également la recevabilité et le
+      bien-fondé de cette action lorsqu’à la suite d’un traitement médico-chirurgical suivi dans un
+      but thérapeutique, une personne présentant le syndrome du transsexualisme ne possède plus tous
+      les caractères de son sexe d’origine et a pris l’apparence physique la rapprochant de l’autre
+      sexe, auquel correspond son comportement social : Le principe du respect de la vie privé
+      justifie alors que son état civil indique désormais le sexe dont elle a pris l’apparence.
+    </p>
+    <p>(Deux arrêts de principe rendus en assemblée plénière le 11 Décembre 1992)</p>
+    <p>
+      La Cour de Cassation a confirmé sa position le 18 octobre 1994 en précisant la référence au
+      principe du respect dû à la vie privée posé, non seulement sur l’article 8 de la Convention
+      Européenne des Droits de l’Homme, mais également par l’article 9 du Code Civil (Cass. 1ère
+      civ., 18octobre 1994 : Defrénois 1995, p.721, obs Massip ; RTD civ 1995, obs. Hauser.)
     </p>
     <p>
-      (Deux arrêts de principe rendus en assemblée plénière le 11 Décembre 1992)
+      L’article 56 de la loi n° 2016-1547 du 18 novembre 2016 de modernisation de la Justice du
+      XXIème siècle – validé par le Conseil Constitutionnel dans sa décision n° 2016-739 DC du 17
+      novembre 2016 – vient introduire quatre nouveaux articles dans le Code Civil.
     </p>
-    <p>
-      La Cour de Cassation a confirmé sa position le 18 octobre 1994 en précisant la référence au principe du respect dû à
-      la vie privée posé, non seulement sur l’article 8 de la Convention Européenne des Droits de l’Homme, mais également
-      par l’article 9 du Code Civil (Cass. 1ère civ., 18octobre 1994 : Defrénois 1995, p.721, obs Massip ; RTD civ 1995,
-      obs. Hauser.)
-    </p>
-    <p>
-      L’article 56 de la loi n° 2016-1547 du 18 novembre 2016 de modernisation de la Justice du XXIème siècle – validé par
-      le Conseil Constitutionnel dans sa décision n° 2016-739 DC du 17 novembre 2016 – vient introduire quatre nouveaux
-      articles dans le Code Civil.
-    </p>
-    <p>
-      L’article 61-5 du Code Civil pose le principe que :
-    </p>
+    <p>L’article 61-5 du Code Civil pose le principe que :</p>
     <blockquote>
       <p>
-        « Toute personne majeure ou mineur émancipée qui démontre par une réunion suffisante de faits que la mention
-        relative à son sexe dans les actes de l’état civil ne correspondant pas à celui <strong>dans lequel elle se
-          présente et dans lequel elle est connue</strong> peut en obtenir la modification.
+        « Toute personne majeure ou mineur émancipée qui démontre par une réunion suffisante de
+        faits que la mention relative à son sexe dans les actes de l’état civil ne correspondant pas
+        à celui
+        <strong>dans lequel elle se présente et dans lequel elle est connue</strong> peut en obtenir
+        la modification.
       </p>
       <p>
-        Les principaux de ces faits, dont la preuve peut être rapportée par tous moyens, peuvent être :
+        Les principaux de ces faits, dont la preuve peut être rapportée par tous moyens, peuvent
+        être :
       </p>
       <ol>
         <li>
           Qu’elle se <strong>présente publiquement</strong> comme appartenant au sexe revendiqué ;
         </li>
         <li>
-          Qu’elle est <strong>connue sous le sexe revendiqué</strong> de son entourage familial, amical ou professionnel ;
+          Qu’elle est <strong>connue sous le sexe revendiqué</strong> de son entourage familial,
+          amical ou professionnel ;
         </li>
         <li>
-          Qu’elle a <strong>obtenu le changement de son prénom</strong> afin qu’il corresponde au sexe revendiqué ; »
+          Qu’elle a <strong>obtenu le changement de son prénom</strong> afin qu’il corresponde au
+          sexe revendiqué ; »
         </li>
       </ol>
     </blockquote>
-    <p>
-      L’article 61-6 dudit code ajoute :
-    </p>
+    <p>L’article 61-6 dudit code ajoute :</p>
     <blockquote>
+      <p>« La demande est présentée devant <strong>le tribunal de grande instance</strong>.</p>
       <p>
-        « La demande est présentée devant <strong>le tribunal de grande instance</strong>.
+        Le demandeur fait état de son consentement libre et éclairé à la modification de la mention
+        relative à son sexe dans les actes de l'état civil et produit tous éléments de preuve au
+        soutien de sa demande.
       </p>
       <p>
-        Le demandeur fait état de son consentement libre et éclairé à la modification de la mention relative à son sexe
-        dans les actes de l'état civil et produit tous éléments de preuve au soutien de sa demande.
+        <strong
+          >Le fait de ne pas avoir subi des traitements médicaux, une opération chirurgicale ou une
+          stérilisation ne peut motiver le refus de faire droit à la demande.</strong
+        >
       </p>
       <p>
-        <strong>Le fait de ne pas avoir subi des traitements médicaux, une opération chirurgicale ou une stérilisation ne
-          peut motiver le refus de faire droit à la demande.</strong>
-      </p>
-      <p>
-        Le tribunal constate que le demandeur satisfait aux conditions fixées à l'article 61-5 et ordonne la modification
-        de la mention relative au sexe <strong>ainsi que, le cas échéant, des prénoms, dans les actes de l'état
-          civil.</strong> »
+        Le tribunal constate que le demandeur satisfait aux conditions fixées à l'article 61-5 et
+        ordonne la modification de la mention relative au sexe
+        <strong>ainsi que, le cas échéant, des prénoms, dans les actes de l'état civil.</strong> »
       </p>
     </blockquote>
-    <p>
-      Une fois le changement d’état civil accordé, l’article 61-7 du code précité précise que :
-    </p>
+    <p>Une fois le changement d’état civil accordé, l’article 61-7 du code précité précise que :</p>
     <blockquote>
       <p>
-        « Mention de la décision de modification du sexe et, le cas échéant, des prénoms est portée en marge de l'acte de
-        naissance de l'intéressé, <strong>à la requête du procureur de la République, dans les quinze jours suivant la
-          date à laquelle cette décision est passée en force de chose jugée.</strong>
+        « Mention de la décision de modification du sexe et, le cas échéant, des prénoms est portée
+        en marge de l'acte de naissance de l'intéressé,
+        <strong
+          >à la requête du procureur de la République, dans les quinze jours suivant la date à
+          laquelle cette décision est passée en force de chose jugée.</strong
+        >
       </p>
       <p>
-        Par dérogation à l'article 61-4, les modifications de prénoms corrélatives à une décision de modification de sexe
-        ne sont portées en marge des actes de l'état civil des conjoints et enfants qu'avec le consentement des intéressés
-        ou de leurs représentants légaux.
+        Par dérogation à l'article 61-4, les modifications de prénoms corrélatives à une décision de
+        modification de sexe ne sont portées en marge des actes de l'état civil des conjoints et
+        enfants qu'avec le consentement des intéressés ou de leurs représentants légaux.
       </p>
-      <p>
-        Les articles 100 et 101 sont applicables aux modifications de sexe. »
-      </p>
+      <p>Les articles 100 et 101 sont applicables aux modifications de sexe. »</p>
     </blockquote>
-    <p>
-      Enfin, l’article 61-8 du Code civil dispose que :
-    </p>
+    <p>Enfin, l’article 61-8 du Code civil dispose que :</p>
     <blockquote>
       <p>
-        « La modification de la mention du sexe dans les actes de l'état civil est sans effet sur les obligations
-        contractées à l'égard de tiers ni sur les filiations établies avant cette modification. »
+        « La modification de la mention du sexe dans les actes de l'état civil est sans effet sur
+        les obligations contractées à l'égard de tiers ni sur les filiations établies avant cette
+        modification. »
       </p>
     </blockquote>
 
     <p>
-      <strong>Ce faisant le changement de sexe à l’état civil est totalement démédicalisé et se fonde désormais uniquement
-        sur la détermination sociale de son sexe par la personne et sa reconnaissance par son entourage.</strong>
+      <strong
+        >Ce faisant le changement de sexe à l’état civil est totalement démédicalisé et se fonde
+        désormais uniquement sur la détermination sociale de son sexe par la personne et sa
+        reconnaissance par son entourage.</strong
+      >
     </p>
     <p>
-      <strong>Le législateur a en outre pris la peine d’indiquer directement dans la loi que :</strong>
+      <strong
+        >Le législateur a en outre pris la peine d’indiquer directement dans la loi que :</strong
+      >
     </p>
     <blockquote>
       <p>
-        <strong>« Le fait de ne pas avoir subi des traitements médicaux, une opération chirurgicale ou une stérilisation
-          ne peut motiver le refus de faire droit à la demande. »</strong>
-      </p>
-    </blockquote>
-    <p>
-      Cela a été confirmé par <strong>la cour d’appel de Montpellier dans l’arrêt du 15 mars 2017 :</strong>
-    </p>
-    <blockquote>
-      <p>
-        « La personne <strong>ne</strong> doit <strong>plus établir</strong> […] la réalité du syndrome transsexuel […]
-        ainsi que le caractère irréversible de la transformation de l’apparence.
-      </p>
-      <p>
-        <strong>La reconnaissance sociale</strong>, posée par la loi nouvelle du 18 novembre 2016 <strong>comme seule
-          condition</strong> à la modification de la mention du sexe à l’état civil. »
-      </p>
-    </blockquote>
-    <p>La France a aussi été condamnée par <strong>la cour européenne des droits de l’Homme le 6 avril 2017 :</strong></p>
-    <blockquote>
-      <p>
-        « Le rejet de la demande […] tendant à la modification de leur état civil au motif qu’ils n’avaient pas
-        <strong>établi le caractère irréversible de la transformation de leur apparence</strong>, c'est-à-dire démontré
-        avoir subi une opération stérilisante ou un traitement médical entraînant une très forte probabilité de stérilité,
-        <strong>s’analyse en un manquement par l’Etat défendeur à son obligation positive de garantir le droit de ces
-          derniers au respect de leur vie privée. Il y a donc, de ce chef, violation de l’article 8 de la Convention à
-          leur égard.</strong> »
-      </p>
-    </blockquote>
-    <p>De plus, il est inutile d’apporter des preuves pour tous les principaux faits mentionnés à l’article 61-5 du Code
-      Civil comme le stipule l’arrêt de la cour d’appel de Montpellier du 15 mars 2017 :</p>
-    <blockquote>
-      <p>
-        « L’emploi, par le législateur, des termes « principaux de ces faits … peuvent être », permet de considérer que
-        l’énumération de ces faits et circonstances n’est <strong>ni exhaustives, ni cumulatives</strong>. »
+        <strong
+          >« Le fait de ne pas avoir subi des traitements médicaux, une opération chirurgicale ou
+          une stérilisation ne peut motiver le refus de faire droit à la demande. »</strong
+        >
       </p>
     </blockquote>
     <p>
-      Cela était, d’ailleurs, la volonté du législateur. J.J. URVOAS, alors ministre de la justice, a clairement précisé
-      lors de la séance plénière du jeudi 19 mai 2016 en première lecture à l’Assemblée Nationale consacré au projet de
-      loi de modernisation de la justice du XXIème siècle que :
-    </p>
-    <blockquote>
-      « La réunion d’<strong>une série de faits énumérés à titre indicatif</strong> permet selon la méthode du faisceau
-      d’indices »
-    </blockquote>
-    <p>
-      Lors de la commission des lois du mercredi 29 juin 2016 consacrée au même projet de loi, Pascale CROZON, alors
-      députée, rappelle « par ailleurs que <strong>ces faits ne sont pas cumulatifs</strong> ». Enfin, lors de la 1ère
-      séance plénière du 12 juillet 2016 à l’Assemblée Nationale, le député Sergio CORONADO ajoute :
+      Cela a été confirmé par
+      <strong>la cour d’appel de Montpellier dans l’arrêt du 15 mars 2017 :</strong>
     </p>
     <blockquote>
       <p>
-        « Les éléments de preuve pouvant être apportés par tous moyens par la personne, et énumérés dans le même article,
+        « La personne <strong>ne</strong> doit <strong>plus établir</strong> […] la réalité du
+        syndrome transsexuel […] ainsi que le caractère irréversible de la transformation de
+        l’apparence.
+      </p>
+      <p>
+        <strong>La reconnaissance sociale</strong>, posée par la loi nouvelle du 18 novembre 2016
+        <strong>comme seule condition</strong> à la modification de la mention du sexe à l’état
+        civil. »
+      </p>
+    </blockquote>
+    <p>
+      La France a aussi été condamnée par
+      <strong>la cour européenne des droits de l’Homme le 6 avril 2017 :</strong>
+    </p>
+    <blockquote>
+      <p>
+        « Le rejet de la demande […] tendant à la modification de leur état civil au motif qu’ils
+        n’avaient pas
+        <strong>établi le caractère irréversible de la transformation de leur apparence</strong>,
+        c'est-à-dire démontré avoir subi une opération stérilisante ou un traitement médical
+        entraînant une très forte probabilité de stérilité,
+        <strong
+          >s’analyse en un manquement par l’Etat défendeur à son obligation positive de garantir le
+          droit de ces derniers au respect de leur vie privée. Il y a donc, de ce chef, violation de
+          l’article 8 de la Convention à leur égard.</strong
+        >
+        »
+      </p>
+    </blockquote>
+    <p>
+      De plus, il est inutile d’apporter des preuves pour tous les principaux faits mentionnés à
+      l’article 61-5 du Code Civil comme le stipule l’arrêt de la cour d’appel de Montpellier du 15
+      mars 2017 :
+    </p>
+    <blockquote>
+      <p>
+        « L’emploi, par le législateur, des termes « principaux de ces faits … peuvent être »,
+        permet de considérer que l’énumération de ces faits et circonstances n’est
+        <strong>ni exhaustives, ni cumulatives</strong>. »
+      </p>
+    </blockquote>
+    <p>
+      Cela était, d’ailleurs, la volonté du législateur. J.J. URVOAS, alors ministre de la justice,
+      a clairement précisé lors de la séance plénière du jeudi 19 mai 2016 en première lecture à
+      l’Assemblée Nationale consacré au projet de loi de modernisation de la justice du XXIème
+      siècle que :
+    </p>
+    <blockquote>
+      « La réunion d’<strong>une série de faits énumérés à titre indicatif</strong> permet selon la
+      méthode du faisceau d’indices »
+    </blockquote>
+    <p>
+      Lors de la commission des lois du mercredi 29 juin 2016 consacrée au même projet de loi,
+      Pascale CROZON, alors députée, rappelle « par ailleurs que
+      <strong>ces faits ne sont pas cumulatifs</strong> ». Enfin, lors de la 1ère séance plénière du
+      12 juillet 2016 à l’Assemblée Nationale, le député Sergio CORONADO ajoute :
+    </p>
+    <blockquote>
+      <p>
+        « Les éléments de preuve pouvant être apportés par tous moyens par la personne, et énumérés
+        dans le même article,
         <strong>ne peuvent être cumulatifs</strong> ».
       </p>
     </blockquote>
 
     <template v-if="data.typeChangement === 'prénomEtGenre'">
-      <p>Le changement de prénom seul relève désormais de la seule compétence des officiers de l’état civil.</p>
+      <p>
+        Le changement de prénom seul relève désormais de la seule compétence des officiers de l’état
+        civil.
+      </p>
       <p>Toutefois, l’article 61-6 alinéa 4 du Code civil prévoit que :</p>
       <blockquote>
-        <p>« Le tribunal constate que le demandeur satisfait aux conditions fixées à l'article 61-5 et ordonne la
-          modification de la mention relative au sexe <strong>ainsi que, le cas échéant, des prénoms, dans les actes de
-            l'état civil.</strong></p>
+        <p>
+          « Le tribunal constate que le demandeur satisfait aux conditions fixées à l'article 61-5
+          et ordonne la modification de la mention relative au sexe
+          <strong>ainsi que, le cas échéant, des prénoms, dans les actes de l'état civil.</strong>
+        </p>
       </blockquote>
-      <p>Ainsi, le Tribunal Judiciaire est compétent pour ordonner un changement de prénom lorsqu’il est saisi
-        d’une telle demande accompagnée d’une demande de modification de la mention relative au sexe.</p>
+      <p>
+        Ainsi, le Tribunal Judiciaire est compétent pour ordonner un changement de prénom lorsqu’il
+        est saisi d’une telle demande accompagnée d’une demande de modification de la mention
+        relative au sexe.
+      </p>
     </template>
     <h2>Ma requête</h2>
     <p>
-      C'est dans ces conditions que je souhaite bénéficier de la loi du 18 novembre 2016 de modernisation de la Justice du
-      XXIème siècle afin de faire modifier :
+      C'est dans ces conditions que je souhaite bénéficier de la loi du 18 novembre 2016 de
+      modernisation de la Justice du XXIème siècle afin de faire modifier :
     </p>
     <ul>
       <li v-if="data.typeChangement === 'prénomEtGenre'">
-        Mes prénoms : rectification des prénoms {{ renderValue('prénomsActuels') }} pour {{ renderValue('nouveauxPrénoms')
-        }}
+        Mes prénoms : rectification des prénoms {{ renderValue('prénomsActuels') }} pour
+        {{ renderValue('nouveauxPrénoms') }}
       </li>
       <li>
-        La mention du sexe sur mon état civil : rectification de la mention {{ genderSwitch('féminin', 'masculin') }} pour
+        La mention du sexe sur mon état civil : rectification de la mention
+        {{ genderSwitch('féminin', 'masculin') }} pour
         {{ genderSwitch('masculin', 'féminin') }}
       </li>
     </ul>
     <p>
-      Ce changement me permettra d'avoir une identité administrative conforme à mon identité de genre, ce qui protégera ma
-      vie privée des actes de la vie courante qui nécessitent de prouver son identité, et m'évitera ainsi de continuer à
-      subir de la discrimination.
+      Ce changement me permettra d'avoir une identité administrative conforme à mon identité de
+      genre, ce qui protégera ma vie privée des actes de la vie courante qui nécessitent de prouver
+      son identité, et m'évitera ainsi de continuer à subir de la discrimination.
     </p>
     <p>
       Afin d'étayer ma requête, je fournis des témoignages et preuves de mon identité au quotidien.
-      Toutes ces pièces vont dans le sens de l'affirmation de mon identité {{ renderValue('genre') }}e
-      et de ma volonté d'être {{ renderWithGender('connu') }} et {{ renderWithGender('reconnu') }}
-      en tant {{ genderSwitch("qu'homme", 'que femme') }}
+      Toutes ces pièces vont dans le sens de l'affirmation de mon identité
+      {{ renderValue('genre') }}e et de ma volonté d'être {{ renderWithGender('connu') }} et
+      {{ renderWithGender('reconnu') }} en tant
+      {{ genderSwitch("qu'homme", 'que femme') }}
       <template v-if="data.typeChangement === 'prénomEtGenre'">
         et sous le(s) prénom(s) de {{ renderValue('nouveauxPrénoms') }}.
       </template>
     </p>
     <h2>Par ces motifs, plaise au tribunal :</h2>
     <p>Vu les articles 9, 60, 61-5 et suivants du Code Civil.</p>
-    <p>Vu l’article 8 de la Convention Européenne de Sauvegarde des Droits de l’Homme et des Libertés Fondamentales.</p>
+    <p>
+      Vu l’article 8 de la Convention Européenne de Sauvegarde des Droits de l’Homme et des Libertés
+      Fondamentales.
+    </p>
     <p>
       {{ genderSwitch('Madame', 'Monsieur', 'genre') }}
       {{ renderValue('nom').toUpperCase() }} {{ renderValue('prénomsActuels') }}
       {{ renderWithGender('dit') }}
       {{ genderSwitch('Monsieur', 'Madame', 'genre') }}
-      {{ renderValue('nom').toUpperCase() }} {{ renderValue('nouveauxPrénoms', data.prénomsActuels) }}
-      demande au Président du Tribunal Judiciaire de {{ renderValue('villeTribunal') }} d'appliquer les requêtes suivantes
-      :
+      {{ renderValue('nom').toUpperCase() }}
+      {{ renderValue('nouveauxPrénoms', data.prénomsActuels) }} demande au Président du Tribunal
+      Judiciaire de {{ renderValue('villeTribunal') }} d'appliquer les requêtes suivantes :
     </p>
     <ul>
       <li v-if="data.typeChangement === 'prénomEtGenre'">
         <strong>ORDONNER</strong>
-        que l’acte de naissance<template v-if="(data['actesÀMettreÀJour'] || '').trim().length > 0">, {{
-          (data['actesÀMettreÀJour'] || '').trim().split('\n').map(e => e.trim()).filter(e => e.length > 0).join(', ') }}
+        que l’acte de naissance<template v-if="(data['actesÀMettreÀJour'] || '').trim().length > 0"
+          >,
+          {{
+            (data['actesÀMettreÀJour'] || '')
+              .trim()
+              .split('\n')
+              .map((e) => e.trim())
+              .filter((e) => e.length > 0)
+              .join(', ')
+          }}
         </template>
 
-        de {{ renderValue('prénomsActuels') }} {{ renderValue('nom').toUpperCase() }} soient rectifié(s) en ce sens que la
-        mention « {{ renderValue('prénomsActuels') }} » soit remplacée par la mention « {{ renderValue('nouveauxPrénoms')
-        }} ».
+        de {{ renderValue('prénomsActuels') }} {{ renderValue('nom').toUpperCase() }} soient
+        rectifié(s) en ce sens que la mention « {{ renderValue('prénomsActuels') }} » soit remplacée
+        par la mention « {{ renderValue('nouveauxPrénoms') }} ».
       </li>
       <li>
         <strong>ORDONNER</strong>
-        que l’acte de naissance<template v-if="(data['actesÀMettreÀJour'] || '').trim().length > 0">, {{
-          (data['actesÀMettreÀJour'] || '').trim().split('\n').map(e => e.trim()).filter(e => e.length > 0).join(', ') }}
+        que l’acte de naissance<template v-if="(data['actesÀMettreÀJour'] || '').trim().length > 0"
+          >,
+          {{
+            (data['actesÀMettreÀJour'] || '')
+              .trim()
+              .split('\n')
+              .map((e) => e.trim())
+              .filter((e) => e.length > 0)
+              .join(', ')
+          }}
         </template>
 
-        de {{ renderValue('prénomsActuels') }} {{ renderValue('nom').toUpperCase() }} soient rectifié(s) en ce sens que la
-        mention « sexe {{ genderSwitch('féminin', 'masculin ') }} » soit remplacée par la mention « sexe {{
-          genderSwitch('masculin', 'féminin') }} ».
-        et que la mention « {{ genderSwitch('née', 'né') }} » soit remplacée par la mention « {{ genderSwitch('né', 'née')
-        }} ».
+        de {{ renderValue('prénomsActuels') }} {{ renderValue('nom').toUpperCase() }} soient
+        rectifié(s) en ce sens que la mention « sexe {{ genderSwitch('féminin', 'masculin ') }} »
+        soit remplacée par la mention « sexe {{ genderSwitch('masculin', 'féminin') }} ». et que la
+        mention « {{ genderSwitch('née', 'né') }} » soit remplacée par la mention «
+        {{ genderSwitch('né', 'née') }} ».
       </li>
       <li>
         <strong>RAPPELER</strong>
-        qu’en vertu de l’article 61-7 du Code Civil, la mention de la décision de modification du sexe est portée en marge
-        de l’acte de naissance de l’{{ renderWithGender('intéressé') }}, à la requête du procureur de la République, dans
-        les quinze jours suivant la date à laquelle cette décision est passée en force de chose jugée.
+        qu’en vertu de l’article 61-7 du Code Civil, la mention de la décision de modification du
+        sexe est portée en marge de l’acte de naissance de l’{{ renderWithGender('intéressé') }}, à
+        la requête du procureur de la République, dans les quinze jours suivant la date à laquelle
+        cette décision est passée en force de chose jugée.
       </li>
       <li>
-        <strong>ORDONNER</strong> qu’aucune expédition des actes d’État civil sans la mention desdites rectifications ne
-        soit délivrée.
+        <strong>ORDONNER</strong> qu’aucune expédition des actes d’État civil sans la mention
+        desdites rectifications ne soit délivrée.
       </li>
     </ul>
     <p>Fait à {{ renderValue('villeDocument') }}, le {{ renderDate('dateDocument') }}</p>
@@ -324,16 +381,17 @@ const { renderValue, genderSwitch, renderWithGender, renderDate } = useDocumentT
       Signature de
       {{ renderValue('nom').toUpperCase() }} {{ renderValue('prénomsActuels') }}
       {{ renderWithGender('dit') }}
-      {{ renderValue('nom').toUpperCase() }} {{ renderValue('nouveauxPrénoms', data.prénomsActuels) }}
+      {{ renderValue('nom').toUpperCase() }}
+      {{ renderValue('nouveauxPrénoms', data.prénomsActuels) }}
     </p>
-    <hr class="hidden">
-    <hr class="hidden">
-    <hr class="hidden">
-    <hr class="hidden">
-    <hr class="hidden">
-    <hr class="hidden">
-    <hr class="hidden">
-    <hr class="hidden">
+    <hr class="hidden" />
+    <hr class="hidden" />
+    <hr class="hidden" />
+    <hr class="hidden" />
+    <hr class="hidden" />
+    <hr class="hidden" />
+    <hr class="hidden" />
+    <hr class="hidden" />
     <h2>Bordereau de pièces</h2>
     <ol class="list--piece">
       <template v-for="e in (data['justificatifsRequête'] || '').split('\n')">

--- a/src/documents.js
+++ b/src/documents.js
@@ -47,7 +47,7 @@ export const fields = [
     id: 'lieuNaissance',
     name: 'Commune et département de naissance',
     type: 'text',
-    placeholder: 'Marseille (13)',
+    placeholder: 'Marseille (13)'
   },
   {
     id: 'adresse',
@@ -70,7 +70,6 @@ export const fields = [
   //   type: 'textarea',
   //   persist: false,
   // },
-  
   {
     id: 'société',
     name: 'Nom de la société',
@@ -110,7 +109,7 @@ function category(name) {
   return {
     name,
     isCategory: true,
-    showCondition: () => true,
+    showCondition: () => true
   }
 }
 function field(id, params = {}) {
@@ -129,10 +128,10 @@ function field(id, params = {}) {
 export const templates = [
   {
     id: 'demande-maj',
-    name: "Demande de mise à jour de prénom et/ou civilité",
-  template: `DemandeMaj`,
+    name: 'Demande de mise à jour de prénom et/ou civilité',
+    template: `DemandeMaj`,
     description:
-      "Pour demander à une entité, entreprise ou administration de mettre à jour vos informations.",
+      'Pour demander à une entité, entreprise ou administration de mettre à jour vos informations.',
     help: `
 
 <br>
@@ -155,22 +154,22 @@ au préalable pour que la demande de changement de civilité aboutisse.**
           { value: `enseignement`, label: 'École ou université' },
           { value: `impôts`, label: 'Impôts' },
           { value: `poleEmploi`, label: 'France Travail' },
-          { value: `autre`, label: 'Autre organisme : banque, EDF, Opérateur mobile ou internet, etc.' },
+          {
+            value: `autre`,
+            label: 'Autre organisme : banque, EDF, Opérateur mobile ou internet, etc.'
+          }
         ],
         action: (data) => {
           if (data.organisme === 'cpam') {
             data.refOrganismeType = 'Numéro de sécurité sociale'
             data.ligneDestinataire = `À l'attention de la CPAM du <Département>`
-          }
-          else if (data.organisme === 'enseignement') {
+          } else if (data.organisme === 'enseignement') {
             data.refOrganismeType = 'Numéro étudiant'
             data.ligneDestinataire = `À l'attention du service scolarité de <École>`
-          }
-          else if (data.organisme === 'poleEmploi') {
+          } else if (data.organisme === 'poleEmploi') {
             data.refOrganismeType = 'Numéro'
             data.ligneDestinataire = `À l'attention de France Travail (<Ville>)`
-          }
-          else if (data.organisme === 'impôts') {
+          } else if (data.organisme === 'impôts') {
             data.refOrganismeType = 'Numéro fiscal'
             data.ligneDestinataire = `À l'attention du Service des Impôts des Particuliers de <Ville>`
           } else {
@@ -182,12 +181,12 @@ au préalable pour que la demande de changement de civilité aboutisse.**
       field('ligneDestinataire', {
         name: `Service recevant la demande`,
         type: 'textarea',
-        attributes: {rows: 3},
+        attributes: { rows: 3 },
         class: 'field--fullwidth',
         placeholder: `À l'attention de <service>`,
         default: () => {
           return null
-        },
+        }
       }),
       field('refOrganismeType', {
         name: `Type de référence`,
@@ -206,14 +205,14 @@ Sélectionnez "Aucune" si vous n'êtes pas sûr·e ou ne disposez pas d'une tell
           { label: `Numéro de contrat`, value: 'Numéro de contrat' },
           { label: `Numéro de sécurité sociale`, value: 'Numéro de sécurité sociale' },
           { label: `Numéro étudiant`, value: 'Numéro étudiant' },
-          { label: `Numéro fiscal`, value: 'Numéro fiscal' },
+          { label: `Numéro fiscal`, value: 'Numéro fiscal' }
         ]
       }),
       field('refOrganisme', {
-        name: `Référence auprès de l'oganisme`,
+        name: `Référence auprès de l'organisme`,
         help: `Par exemple votre numéro de contrat, numéro de compte, identifiant client, numéro de sécurité sociale, etc.`,
         type: 'text',
-        persist: false,
+        persist: false
       }),
       category('Votre demande'),
       field('changementDemandé', {
@@ -226,17 +225,19 @@ Sélectionnez "Aucune" si vous n'êtes pas sûr·e ou ne disposez pas d'une tell
         choices: [
           { label: `Mise à jour du prénom`, value: 'prénom' },
           { label: `Mise à jour de la civilité`, value: 'civilité' },
-          { label: `Mise à jour du prénom et de la civilité`, value: 'prénomEtCivilité' },
+          { label: `Mise à jour du prénom et de la civilité`, value: 'prénomEtCivilité' }
         ]
       }),
       category('Vos informations'),
-      field('prénom', {help: `Il s'agit de vos prénoms revendiqués, séparés par une virgule`}),
+      field('prénom', { help: `Il s'agit de vos prénoms revendiqués, séparés par une virgule` }),
       field('nom'),
       field('civilité', {
-        help: "Il s'agit de votre civilité revendiquée",
+        help: "Il s'agit de votre civilité revendiquée"
       }),
       field('deadname', {
-        showCondition: (data) => {return data.changementDemandé != 'civilité'},
+        showCondition: (data) => {
+          return data.changementDemandé != 'civilité'
+        }
       }),
       field('adresse'),
       field('email'),
@@ -244,19 +245,23 @@ Sélectionnez "Aucune" si vous n'êtes pas sûr·e ou ne disposez pas d'une tell
       category('Options du document'),
       field('ajouterCSEC', {
         type: 'checkbox',
-        default: () => {return false},
+        default: () => {
+          return false
+        },
         name: `Appuyer la demande de changement de civilité avec la décision de changement de sexe à l'état civil.`,
-        showCondition: (data) => {return data.changementDemandé != 'prénom'},
+        showCondition: (data) => {
+          return data.changementDemandé != 'prénom'
+        }
       }),
       field('mentionDDDEtCnil', {
         type: 'checkbox',
         default: () => {
           return false
         },
-        name: `Ajouter une mention sur la saisie potentielle du Défenseur des Droits et de la CNIL`,
+        name: `Ajouter une mention sur la saisie potentielle du Défenseur des Droits et de la CNIL`
       }),
       field('villeDocument'),
-      field('dateDocument'),
+      field('dateDocument')
     ]
   },
   {
@@ -273,7 +278,7 @@ Sélectionnez "Aucune" si vous n'êtes pas sûr·e ou ne disposez pas d'une tell
       category('Tribunal et type de requête'),
       field('tribunal', {
         name: 'Nom du tribunal',
-        placeholder: 'Tribunal Judiciaire de Toulouse',
+        placeholder: 'Tribunal Judiciaire de Toulouse'
       }),
       field('adresseTribunal', {
         name: 'Adresse du tribunal',
@@ -282,7 +287,7 @@ Sélectionnez "Aucune" si vous n'êtes pas sûr·e ou ne disposez pas d'une tell
       field('villeTribunal', {
         name: 'Ville du tribunal',
         type: 'text',
-        placeholder: 'Toulouse',
+        placeholder: 'Toulouse'
       }),
       field('typeChangement', {
         name: `Type de demande`,
@@ -292,23 +297,29 @@ Sélectionnez "Aucune" si vous n'êtes pas sûr·e ou ne disposez pas d'une tell
         },
         choices: [
           { label: `Changement mention de sexe`, value: 'genre' },
-          { label: `Changement de prénom et de mention de sexe`, value: 'prénomEtGenre' },
+          { label: `Changement de prénom et de mention de sexe`, value: 'prénomEtGenre' }
         ]
       }),
       category('Vos informations'),
 
-      field('genre', {help: `Il s'agit genre désiré/revendiqué`}),
+      field('genre', { help: `Il s'agit du genre désiré/revendiqué` }),
       field('prénom', {
         id: 'nouveauxPrénoms',
         name: `Prénom(s) demandés`,
         help: `Il s'agit de vos nouveaux prénoms, séparés par une virgule`,
-        showCondition: (data) => {return data.typeChangement === 'prénomEtGenre'},
+        showCondition: (data) => {
+          return data.typeChangement === 'prénomEtGenre'
+        }
       }),
-      field('prénom', {id: 'prénomsActuels', name: `Prénom(s) actuels`, help: `Il s'agit de vos prénoms actuels à l'état civil, séparés par une virgule`}),
+      field('prénom', {
+        id: 'prénomsActuels',
+        name: `Prénom(s) actuels`,
+        help: `Il s'agit de vos prénoms actuels à l'état civil, séparés par une virgule`
+      }),
       field('nom'),
       field('dateNaissance'),
       field('lieuNaissance'),
-      field('nationalité', {type: 'text', name: 'Nationalité', default: () => 'française'}),
+      field('nationalité', { type: 'text', name: 'Nationalité', default: () => 'française' }),
       field('adresse'),
       field('email'),
       field('téléphone'),
@@ -326,14 +337,14 @@ Sélectionnez "Aucune" si vous n'êtes pas sûr·e ou ne disposez pas d'une tell
       field('contexte', {
         name: 'Contexte de la requête',
         type: 'textarea',
-        attributes: {rows: 10},
+        attributes: { rows: 10 },
         help: `Utilisez cet endroit pour personnaliser le corps de la requête et justifier votre demande.
 Il n'est pas nécessaire de donner des justifications d'ordre médical, psychiatrique,
 chirurgicales sauf si vous le souhaitez.
 
 Il est préférable d'éviter de rentrer trop dans l'intime pour éviter de normaliser cela auprès des 
 personnes examinant les dossiers. Néanmoins, cela peut s'avérer nécessaire si le tribunal
-auprès duquel vous déposez votre requête à tendance à demander ce genre de détails.`,
+auprès duquel vous déposez votre requête à tendance à demander ce genre de détails.`
       }),
       field('contexteExemple', {
         name: 'Insérer un exemple de contexte',
@@ -352,19 +363,19 @@ auprès duquel vous déposez votre requête à tendance à demander ce genre de 
 Je suis une personne transgenre, c'est-à-dire que mon genre de naissance n'est pas en adéquation avec mon genre réel.
 
 Depuis de nombreuses années, je me présente et vis quotidiennement en tant que {{ sexe }}, tant dans mes relations familiales qu'amicales ou professionnelles.
-Les personnes qui me cotoient au quotidien utilisent cette identité de genre et l'acceptent parfaitement.
+Les personnes qui me côtoient au quotidien utilisent cette identité de genre et l'acceptent parfaitement.
 
 Cette transition sociale s'accompagne également d'autres changements liés à mon apparence, notamment vestimentaires pour me rapprocher de mon genre réel.
 
-Je suis satisfaite de ma transition et je me sens plus équilibrée et en accord avec moi-même depuis que j'ai entrepris ces changements.
+Je suis {{ satisfait }} de ma transition et je me sens plus {{ equilibre }} et en accord avec moi-même depuis que j'ai entrepris ces changements.
             `
-          },
+          }
         ]
       }),
       field('actesÀMettreÀJour', {
         name: 'Actes supplémentaires à mettre à jour',
         type: 'textarea',
-        attributes: {rows: 10},
+        attributes: { rows: 10 },
         help: `
 Le tribunal ordonnera la mise à jour de votre acte de naissance. Selon votre situation, listez ici les autres actes d'état civil pour lesquels le tribunal devra ordonner une mise à jour.
 Un acte par ligne.
@@ -378,7 +389,7 @@ Ces documents doivent être joints à votre requête et listés dans le champ su
       field('justificatifsRequête', {
         name: 'Justificatifs et documents joints',
         type: 'textarea',
-        attributes: {rows: 10},
+        attributes: { rows: 10 },
         help: `
 Listez ici les justificatifs et documents que vous joindrez à votre requête.
 N'incluez aucun certificat médical. Un justificatif par ligne.
@@ -398,7 +409,7 @@ actes d'état civil, comme mon acte de naissance.
 >
 > Signature
 
-**Ce document ne peut être généré ici, vous devrez le rédiger vous même manuscritement.** Afin de faciliter cette étape, nous vous proposons d'utiliser [ce template](/annexe_consentement_eclaire.pdf).
+**Ce document ne peut être généré ici, vous devrez le rédiger vous-même manuscritement.** Afin de faciliter cette étape, nous vous proposons d'utiliser [ce template](/annexe_consentement_eclaire.pdf).
 
 `,
         default: () => `<Obligatoire> Copie intégrale de mon acte de naissance
@@ -423,29 +434,51 @@ Preuves de refus de changement de la part d'organismes tiers`
     name: 'Cerfa pour changement de prénom(s) en mairie ou consulat',
     template: `RequetePrenomMairie`,
     description: 'Cerfa N° 16233*04 pour demande de changement de prénom.',
-    help: `L'original peut-être téléchargé et rempli à la main sur [service-public.fr](https://www.service-public.fr/particuliers/vosdroits/R63177)`,
+    help: `L'original peut être téléchargé et rempli à la main sur [service-public.fr](https://www.service-public.fr/particuliers/vosdroits/R63177)`,
     structure: [
       category('Vos informations'),
       field('nom'),
-      field('nom', {id: 'nomUsage', name: `Nom d'usage ou nom d'époux/épouse`}),
-      field('genre', {id: 'genreÉtatCivil', help: `Il s'agit de votre genre actuel à l'état civil`}),
-      field('prénom', {id: 'prénoms', name: `Prénom(s), séparés par une virgule`, help: `Il s'agit de vos prénoms actuels à l'état civil, séparés par une virgule`}),
+      field('nom', { id: 'nomUsage', name: `Nom d'usage ou nom d'époux/épouse` }),
+      field('genre', {
+        id: 'genreÉtatCivil',
+        help: `Il s'agit de votre genre actuel à l'état civil`
+      }),
+      field('prénom', {
+        id: 'prénoms',
+        name: `Prénom(s), séparés par une virgule`,
+        help: `Il s'agit de vos prénoms actuels à l'état civil, séparés par une virgule`
+      }),
       field('dateNaissance'),
       field('lieuNaissance'),
-      field('nationalités', {type: 'text', name: 'Nationalité(s)', help: 'Séparées par des virgules'}),
-      field('adresseVoie', {type: 'text', name: 'Rue et numéro de rue'}),
-      field('adresseComplément', {type: 'text', name: `Complément d'adresse`}),
-      field('adresseCodePostal', {type: 'text', name: `Code postal`}),
-      field('adresseCommune', {type: 'text', name: `Commune`}),
-      field('adressePays', {type: 'text', name: `Pays`, default: () => {return 'France'}}),
+      field('nationalités', {
+        type: 'text',
+        name: 'Nationalité(s)',
+        help: 'Séparées par des virgules'
+      }),
+      field('adresseVoie', { type: 'text', name: 'Rue et numéro de rue' }),
+      field('adresseComplément', { type: 'text', name: `Complément d'adresse` }),
+      field('adresseCodePostal', { type: 'text', name: `Code postal` }),
+      field('adresseCommune', { type: 'text', name: `Commune` }),
+      field('adressePays', {
+        type: 'text',
+        name: `Pays`,
+        default: () => {
+          return 'France'
+        }
+      }),
       field('email'),
       field('téléphone'),
       category('Votre demande'),
-      field('prénom', {id: 'nouveauxPrénoms', name: `Prénom(s), séparés par une virgule`, help: `Il s'agit des nouveaux prénoms que vous souhaitez, séparés par une virgule`}),
+      field('prénom', {
+        id: 'nouveauxPrénoms',
+        name: `Prénom(s), séparés par une virgule`,
+        help: `Il s'agit des nouveaux prénoms que vous souhaitez, séparés par une virgule`
+      }),
       field('motif', {
         type: 'textarea',
         name: `Motif`,
-        default: () => `Madame, monsieur, je vous demande aujourd'hui le changement de mes prénoms, car je suis une personne transgenre, et après de nombreuses années de réflexion j'ai entamé ma transition autant physiquement que socialement. Mes prénoms de naissance sont un obstacle dans mes démarches administratives, mais aussi pour l'accès à l'emploi ainsi que pour récupérer du courrier. D'avance merci.`
+        default: () =>
+          `Madame, monsieur, je vous demande aujourd'hui le changement de mes prénoms, car je suis une personne transgenre, et après de nombreuses années de réflexion j'ai entamé ma transition autant physiquement que socialement. Mes prénoms de naissance sont un obstacle dans mes démarches administratives, mais aussi pour l'accès à l'emploi ainsi que pour récupérer du courrier. D'avance merci.`
       }),
       field('typeDemande', {
         name: `Type de demande`,
@@ -455,15 +488,17 @@ Preuves de refus de changement de la part d'organismes tiers`
         },
         choices: [
           { label: `C'est votre première demande`, value: 'première' },
-          { label: `Vous avez déjà demandé un changement de prénom(s)`, value: 'plusieurs' },
+          { label: `Vous avez déjà demandé un changement de prénom(s)`, value: 'plusieurs' }
         ]
       }),
       field('demandes', {
         name: `Demandes précédentes`,
-        showCondition: (data) => {return data.typeDemande === 'plusieurs'},
+        showCondition: (data) => {
+          return data.typeDemande === 'plusieurs'
+        },
         type: 'textarea',
         placeholder: '05/09/2021 à Lille, Mairie, 12/11/2021',
-        help: `Une demande par ligne, séparer la date et lieu, l'autorité saisie et la date de décision par une virgule.`,
+        help: `Une demande par ligne, séparer la date et lieu, l'autorité saisie et la date de décision par une virgule.`
       }),
       category('Mise à jour de vos documents et ceux de votre famille'),
       field('majActeNaissance', {
@@ -471,7 +506,7 @@ Preuves de refus de changement de la part d'organismes tiers`
         default: () => {
           return true
         },
-        name: `Demander une mise à jour de votre acte de naissance`,
+        name: `Demander une mise à jour de votre acte de naissance`
       }),
       field('majActeMariage', {
         type: 'checkbox',
@@ -486,7 +521,9 @@ Preuves de refus de changement de la part d'organismes tiers`
       }),
       field('lieuMariage', {
         type: 'text',
-        showCondition: (data) => {return data.majActeMariage},
+        showCondition: (data) => {
+          return data.majActeMariage
+        },
         name: `Lieu de votre mariage`
       }),
       field('majActeNaissanceConjoint', {
@@ -494,16 +531,17 @@ Preuves de refus de changement de la part d'organismes tiers`
         name: `Demander une mise à jour de l'acte de naissance de votre conjoint ou partenaire de PACS`
       }),
       field('nom', {
-        id: 'nomConjoint',
+        id: 'nomConjoint'
       }),
       field('prénom', {
-        id: 'prénomsConjoint', name: `Prénom(s), séparés par une virgule`,
+        id: 'prénomsConjoint',
+        name: `Prénom(s), séparés par une virgule`
       }),
       field('dateNaissance', {
-        id: 'dateNaissanceConjoint',
+        id: 'dateNaissanceConjoint'
       }),
       field('lieuNaissance', {
-        id: 'lieuNaissanceConjoint',
+        id: 'lieuNaissanceConjoint'
       }),
       field('majActeNaissanceEnfants', {
         type: 'checkbox',
@@ -511,10 +549,12 @@ Preuves de refus de changement de la part d'organismes tiers`
       }),
       field('enfants', {
         name: `Informations sur vos enfants`,
-        showCondition: (data) => {return !!data.majActeNaissanceEnfants },
+        showCondition: (data) => {
+          return !!data.majActeNaissanceEnfants
+        },
         type: 'textarea',
         placeholder: 'Lund, Élise, 05/09/2021, Marseille (13)',
-        help: `Un·e enfant par ligne, séparer le nom, prénom, date de naissance et lieu de naissance par une virgule`,
+        help: `Un·e enfant par ligne, séparer le nom, prénom, date de naissance et lieu de naissance par une virgule`
       }),
       category('Finalisation du document'),
       field('villeDocument'),
@@ -544,8 +584,8 @@ et utiliser la fonction « Partager le document »**. Cela lui permettra de l'im
       category(`Information de la personne concernée par l'attestation`),
       field('prénom'),
       field('nom'),
-      field('genre', {help: `Il s'agit genre désiré/revendiqué`}),
-      field('deadname', {name: 'Deadname (facultatif)'}),
+      field('genre', { help: `Il s'agit genre désiré/revendiqué` }),
+      field('deadname', { name: 'Deadname (facultatif)' }),
       field('dateNaissance'),
       field('lieuNaissance'),
 

--- a/src/lib/utils/gender.js
+++ b/src/lib/utils/gender.js
@@ -1,0 +1,7 @@
+export function renderWithGender(word, gender, appendLetter = 'e') {
+  return gender === 'féminin' ? `${word}${appendLetter}` : word
+}
+
+export function genderSwitch(mascWord, femWord, gender) {
+  return gender === 'féminin' ? femWord : mascWord
+}

--- a/src/templates.js
+++ b/src/templates.js
@@ -1,6 +1,11 @@
+import {
+  renderWithGender as rwg,
+  genderSwitch as gs
+} from '@/lib/utils/gender'
+
 export default function useDocumentTemplate(props) {
   const fieldsById = {}
-  props.structure.forEach(e => {
+  props.structure.forEach((e) => {
     if (e.isInput) {
       fieldsById[e.id] = e
     }
@@ -30,18 +35,10 @@ export default function useDocumentTemplate(props) {
     return `<${field}>`
   }
   function renderWithGender(word, genderField = 'genre', appendLetter = 'e') {
-    const gender = props.data[genderField]
-    if (gender === 'féminin') {
-      word = `${word}${appendLetter}`
-    }
-    return word
+    return rwg(word, props.data[genderField], appendLetter)
   }
   function genderSwitch(mascWord, femWord, genderField = 'genre') {
-    const gender = props.data[genderField]
-    if (gender === 'féminin') {
-      return femWord
-    }
-    return mascWord
+    return gs(mascWord, femWord, props.data[genderField])
   }
   function renderFullDescription() {
     let name = renderValue('prénom')
@@ -57,6 +54,6 @@ ${renderWithGender('né')} le ${renderDate('dateNaissance')}
     renderDate,
     renderWithGender,
     genderSwitch,
-    renderFullDescription,
+    renderFullDescription
   }
 }


### PR DESCRIPTION
NOTE: La plupart des modifications sont dûes au respect des règles du prettier.

Modifications
- Accord féminin/masculin dans le contexte de la requête pour le CSEC
- Le texte du contexte est maintenant dynamique, si on change le genre à posteriori, les accords féminins/masuclins changent
- Création d'un dossier `lib/utils` avec extraction de la logique pour les fonctions `renderWithGender` et `genderSwitch` 


fix #67 