### PR TITLE
Remplacer Plausible par Umami auto-hébergé, servi en first-party

### DIFF
--- a/.github/workflows/deploy.prod.yml
+++ b/.github/workflows/deploy.prod.yml
@@ -33,8 +33,9 @@ jobs:
       - name: Build
         run: yarn build
         env:
-          VITE_PLAUSIBLE_TRACKING_DOMAIN: administrans.fr
-          VITE_PLAUSIBLE_URL: https://stats.administrans.fr
+          VITE_UMAMI_SRC: https://in.administrans.fr/u.js
+          VITE_UMAMI_WEBSITE_ID: 4bc91646-7545-4186-b634-991de539575c
+          VITE_UMAMI_DOMAINS: administrans.fr
           VITE_REDIRECT_DOMAIN: administrans.fr
 
       - name: Disable jekyll

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "marked": "4",
     "pinia": "^2.0.32",
     "pinia-plugin-persistedstate": "^3.1.0",
-    "plausible-tracker": "^0.3.8",
     "vite-ssg": "^0.22.2",
     "vue": "^3.2.47",
     "vue-router": "^4.1.6"

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { RouterLink, RouterView } from 'vue-router'
-import { inject, watch, reactive } from 'vue'
+import { watch, reactive } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useGlobalStore } from '@/store'
 import { useHead, useSeoMeta } from '@vueuse/head'
@@ -83,8 +83,6 @@ useSeoMeta({
   twitterDescription: description,
 })
 
-const plausible = inject('plausible')
-
 watch(
   () => route.path,
   (v) => {
@@ -95,13 +93,6 @@ watch(
         router.replace(match.fullPath)
       }
     }
-    const config = ({
-      url: v,
-      domain: window.location.hostname,
-      referrer: document.referrer || null,
-      deviceWidth: window.innerWidth,
-    });
-    plausible.trackEvent('pageview', {}, config)
   },
   {immediate: true},
 )

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -1,0 +1,14 @@
+// Thin adapter over the self-hosted Umami tracker, loaded as a global by the script tag
+// that vite.config.js injects at build time.
+//
+// Pageviews are not sent from here: the tracker tracks them itself, including client-side
+// navigations (it patches history.pushState/replaceState). Only custom events are ours.
+//
+// `umami` is absent during the vite-ssg prerender (no window), when the build has no tracker
+// env vars, before the deferred script has parsed, and when a blocker drops it: in all four
+// cases the call below is a no-op.
+const umami = () => (typeof window === 'undefined' ? null : window.umami)
+
+export function trackEvent(name, data = {}) {
+  umami()?.track(name, data)
+}

--- a/src/components/DocumentForm.vue
+++ b/src/components/DocumentForm.vue
@@ -1,14 +1,10 @@
 <script setup>
-import { reactive, watch, ref, inject } from 'vue'
+import { reactive, watch, ref } from 'vue'
 import DynamicForm from './DynamicForm.vue'
 import { useGlobalStore } from '@/store'
 import {renderMarkdown} from '@/utils'
-import { useRoute } from 'vue-router'
 import documentsComponents from '@/documentsComponents'
-
-const route = useRoute()
-
-const plausible = inject('plausible')
+import { trackEvent } from '@/analytics'
 
 const store = useGlobalStore()
 
@@ -79,7 +75,7 @@ watch(
   manualEdit,
   (v) => {
     if (v) {
-      plausible.trackEvent('edit', { props: { document: props.template.id } }, {url: route.path})
+      trackEvent('edit', { document: props.template.id })
     }
   },
   { deep: true }
@@ -88,7 +84,7 @@ function updateLocalData(v) {
   Object.assign(localData, v)
 }
 function downloadPdf() {
-  plausible.trackEvent('print', { props: { document: props.template.id } }, {url: route.path})
+  trackEvent('print', { document: props.template.id })
   window.print()
 }
 async function shareUrl() {
@@ -104,7 +100,7 @@ async function shareUrl() {
   }
   url = url + '?' + params.toString()
   await window.navigator.clipboard.writeText(url)
-  plausible.trackEvent('share', { props: { document: props.template.id } }, {url: route.path})
+  trackEvent('share', { document: props.template.id })
   alert(`Un lien de partage a été copié dans le presse-papier. Il contient toutes les informations du document, ne le partagez qu'avec des personnes de confiance`)
 
   

--- a/src/components/StepItem.vue
+++ b/src/components/StepItem.vue
@@ -1,12 +1,9 @@
 <script setup>
 import { RouterLink } from 'vue-router'
-import { ref, watch, inject } from 'vue'
+import { ref, watch } from 'vue'
 import { useGlobalStore } from '@/store'
-import { useRoute } from 'vue-router'
+import { trackEvent } from '@/analytics'
 
-const plausible = inject('plausible')
-
-const route = useRoute()
 const props = defineProps({
   stepId: { required: true },
   link: { required: false, default: true },
@@ -20,7 +17,7 @@ const value = ref(store.steps[props.stepId])
 watch(value, (v) => {
   store.setStep(props.stepId, v)
   if (v) {
-    plausible.trackEvent('checkItem', { props: { step: props.stepId } }, {url: route.path})
+    trackEvent('checkItem', { step: props.stepId })
   }
 })
 </script>

--- a/src/main.js
+++ b/src/main.js
@@ -10,30 +10,11 @@ import routerConfig from './router'
 export const createApp = ViteSSG(
   App,
   routerConfig,
-  async ({ app }) => {
+  ({ app }) => {
     const pinia = createPinia()
     pinia.use(piniaPluginPersistedstate)
 
     app.use(pinia)
-
-    if (import.meta.env.VITE_PLAUSIBLE_URL) {
-      console.log('Plausible tracking enabled on ', import.meta.env.VITE_PLAUSIBLE_URL)
-      const Plausible = (await import('plausible-tracker')).default
-      const plausibleOptions = {
-        hashMode: true,
-        apiHost: import.meta.env.VITE_PLAUSIBLE_URL,
-        domain: import.meta.env.VITE_PLAUSIBLE_TRACKING_DOMAIN,
-        trackLocalhost: !!import.meta.env.VITE_PLAUSIBLE_TRACK_LOCALHOST
-      }
-      const plausible = (Plausible.default || Plausible)(plausibleOptions)
-      app.provide('plausible', plausible)
-    } else {
-      app.provide('plausible', {
-        trackEvent: (name, data) => {
-          console.log('[Plausible] Disabled, would send', name, data)
-        }
-      })
-    }
   }
 )
 

--- a/src/views/AboutView.vue
+++ b/src/views/AboutView.vue
@@ -15,7 +15,7 @@ useSeoMeta({
   
 })
 
-const plausibleEnabled = import.meta.env.VITE_PLAUSIBLE_URL
+const analyticsEnabled = import.meta.env.VITE_UMAMI_WEBSITE_ID
 const store = useGlobalStore()
 
 function deleteData() {
@@ -99,7 +99,7 @@ function deleteData() {
     </ul>
     <p>Merci beaucoup et prenez soin de vous &lt;3</p>
   </section>
-  <section class="width--xnarrow my-2" v-if="plausibleEnabled">
+  <section class="width--xnarrow my-2" v-if="analyticsEnabled">
     <h2>Analytique</h2>
     <p>
       Pour avoir une idée de l'utilisation du site et des aspects à améliorer ou retravailler, des

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,36 +1,70 @@
 import { fileURLToPath, URL } from 'node:url'
 
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import vue from '@vitejs/plugin-vue'
 
 import 'vite-ssg'
 import {templates} from './src/documents'
 
+// Injects the self-hosted Umami tracker into every prerendered page. The script is served
+// first-party (in.administrans.fr), so ad-blockers see no third-party request.
+// Without the env vars, no tag is emitted at all: dev and preview builds never send events.
+//
+// exclude-search and exclude-hash are load-bearing, not tuning: the tracker builds the page
+// URL from window.location.href, and here the query string carries the form data of a share
+// link and the hash carries the whole local store (#migrate=). Both must be stripped before
+// anything is sent, otherwise personal data would end up in the dashboard.
+const umamiPlugin = (env) => ({
+  name: 'umami-tracker',
+  transformIndexHtml() {
+    if (!env.VITE_UMAMI_SRC || !env.VITE_UMAMI_WEBSITE_ID) return []
+    return [
+      {
+        tag: 'script',
+        injectTo: 'head',
+        attrs: {
+          defer: true,
+          src: env.VITE_UMAMI_SRC,
+          'data-website-id': env.VITE_UMAMI_WEBSITE_ID,
+          'data-exclude-search': 'true',
+          'data-exclude-hash': 'true',
+          ...(env.VITE_UMAMI_DOMAINS ? { 'data-domains': env.VITE_UMAMI_DOMAINS } : {}),
+        },
+      },
+    ]
+  },
+})
+
 // https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [
-    vue(),
-  ],
-  ssgOptions: {
-    script: 'async',
-    formatting: 'prettify',
-    dirStyle: 'nested',
-    mock: true,
-    includedRoutes(paths, routes) {
-      // include path to documents for prerendering
-      return routes.flatMap((route) => {
-        return route.name === 'documents'
-          ? templates.map(t => `/documents/${t.id}`)
-          : route.path
-      })
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, fileURLToPath(new URL('.', import.meta.url)), 'VITE_')
+
+  return {
+    plugins: [
+      vue(),
+      umamiPlugin(env),
+    ],
+    ssgOptions: {
+      script: 'async',
+      formatting: 'prettify',
+      dirStyle: 'nested',
+      mock: true,
+      includedRoutes(paths, routes) {
+        // include path to documents for prerendering
+        return routes.flatMap((route) => {
+          return route.name === 'documents'
+            ? templates.map(t => `/documents/${t.id}`)
+            : route.path
+        })
+      },
     },
-  },
-  build: {
-    minify: 'esbuild',
-  },
-  resolve: {
-    alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url))
+    build: {
+      minify: 'esbuild',
+    },
+    resolve: {
+      alias: {
+        '@': fileURLToPath(new URL('./src', import.meta.url))
+      }
     }
   }
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1628,11 +1628,6 @@ pkg-types@^1.0.2:
     mlly "^1.2.0"
     pathe "^1.1.0"
 
-plausible-tracker@^0.3.8:
-  version "0.3.8"
-  resolved "https://registry.yarnpkg.com/plausible-tracker/-/plausible-tracker-0.3.8.tgz#9b8b322cc41e0e1d6473869ef234deea365a5a40"
-  integrity sha512-lmOWYQ7s9KOUJ1R+YTOR3HrjdbxIS2Z4de0P/Jx2dQPteznJl2eX3tXxKClpvbfyGP59B5bbhW8ftN59HbbFSg==
-
 postcss-selector-parser@^6.0.9:
   version "6.0.12"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.12.tgz#2efae5ffab3c8bfb2b7fbf0c426e3bca616c4abb"


### PR DESCRIPTION
## Pourquoi

Le tracker Plausible pointait vers `stats.administrans.fr`, qui est un CNAME vers un tiers (`app-01.agate.blue`). C'est exactement la forme que les bloqueurs de publicité neutralisent : un sous-domaine `stats.*`, en tiers, derrière un CNAME que uBlock Origin décloake par défaut sur Firefox. Autrement dit, la collecte était au mieux partielle, et l'intégration était de toute façon morte.

On remplace par notre Umami auto-hébergé sur le cluster. Comme le site est hébergé sur GitHub Pages (donc aucune réécriture possible côté edge), le tracker est servi depuis `in.administrans.fr`, un enregistrement A qui pointe directement sur la Gateway du cluster. C'est un sous-domaine du domaine du site lui-même : les bloqueurs voient une requête same-site, sans CNAME à décloaker. Ce point d'entrée ne sert que `/u.js` et `/api/send`, et renvoie 404 sur tout le reste.

## Configuration

La configuration reste dans l'environnement de build, comme celle de Plausible, via trois variables posées dans `deploy.prod.yml` :

- `VITE_UMAMI_SRC: https://in.administrans.fr/u.js`
- `VITE_UMAMI_WEBSITE_ID: 4bc91646-…`
- `VITE_UMAMI_DOMAINS: administrans.fr`

Sans ces variables (cas par défaut, `yarn dev` par exemple), aucune balise `<script>` n'est injectée : le trafic de développement ne peut pas polluer le tableau de bord. C'est ce que `trackLocalhost: false` apportait auparavant. `data-domains` sert de seconde ligne de défense : un build servi depuis un autre hôte n'enverra rien.

L'identifiant du site n'est pas un secret (il est livré à chaque visiteur dans la page), donc une valeur en clair dans `env:` convient.

## Vie privée : `data-exclude-search` et `data-exclude-hash`

Ces deux attributs ne sont pas du réglage, ils sont indispensables. Le tracker construit l'URL de la page à partir de `window.location.href`, or ici :

- un lien de partage transporte les données du formulaire dans la query string (`?nom=…&prenom=…`)
- le hash `#migrate=` transporte l'intégralité du store local en JSON

Sans ces attributs, ces données personnelles partiraient dans le tableau de bord, ce qui contredirait la page « À propos » qui promet que les données saisies ne sont pas collectées. Vérifié en local : l'URL envoyée est bien réduite au chemin, query string et hash retirés (sur l'URL comme sur le referrer).

## Pages vues et évènements

Umami suit les pages vues tout seul, y compris les navigations côté client (il patche `history.pushState`/`replaceState`, et le routeur est en mode history). On ne renvoie donc pas nos propres pages vues depuis le watcher de route : cela compterait chaque navigation en double. Vérifié en local : une navigation = un seul `/api/send`.

Les quatre évènements métier restent identiques (`edit`, `print`, `share`, `checkItem`), seul le transport change. Umami relève lui-même l'URL, le referrer, l'écran, la langue et l'OS, donc les champs `domain`/`deviceWidth` que Plausible demandait à la main disparaissent, et la charge utile s'aplatit de `{ props: { … } }` à `{ … }`.

## Nettoyage

L'indirection `provide`/`inject` n'existait que pour injecter un stub qui loguait dans la console quand Plausible était désactivé. Umami étant un global chargé par la balise script, un petit module avec un garde de nullité (`src/analytics.js`) la remplace, et ce garde couvre aussi le prerender `vite-ssg`, le build sans tracker, l'instant avant que le script `defer` ne soit parsé, et le cas où un bloqueur l'a supprimé.

La dépendance `plausible-tracker` est retirée. Après ce PR, `grep -ri plausible` ne renvoie plus rien.

## Vérifications

- `yarn build` passe, y compris le prerender SSG (les avertissements `window.scrollTo` de jsdom sont préexistants, ils sont déjà là sur `main`)
- `yarn lint` passe
- build avec les variables : la balise est présente sur les 9 pages prérendues, pas seulement sur l'entrée
- build sans les variables : aucune balise, aucune requête
- build de production chargé sur localhost : `/u.js` est bien chargé mais aucun évènement n'est envoyé, `data-domains` ne correspondant pas